### PR TITLE
fix: 空のアサーションを修正（test_no_toolsets）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,9 @@ __marimo__/
 /drafts/
 # hachimoku
 /.hachimoku/
+
+# issue-workflow
+/.issue-workflow/
+
+# claude code
+/.claude

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -86,8 +86,7 @@ class TestClaudeCodeLocalCodeExecutorAgentInit:
 
         # _function_toolset にツールが登録されていないことを確認
         toolset = getattr(agent.agent, "_function_toolset", None)
-        if toolset is not None:
-            assert len(toolset.tools) == 0
+        assert toolset is None or len(toolset.tools) == 0
 
     @patch(STORE_PATCH)
     @patch(MODEL_PATCH)


### PR DESCRIPTION
## 概要
test_no_toolsets テストのアサーションロジックを修正しました。
toolset が None の場合でもアサーションが正しく評価されるようにしました。

変更内容：
- `if toolset is not None: assert len(toolset.tools) == 0` から単一アサーションに統合
- `assert toolset is None or len(toolset.tools) == 0` で None または空のツールセットをチェック

Closes #2

## テスト計画
- 既存テストスイートで動作確認済み（ruff check, ruff format, mypy パス）
- test_no_toolsets が正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)