### PR TITLE
fix: DatabaseReadError を明示的に伝播させる

### DIFF
--- a/src/quant_insight_plus/agents/agent.py
+++ b/src/quant_insight_plus/agents/agent.py
@@ -67,11 +67,18 @@ class ClaudeCodeLocalCodeExecutorAgent(LocalCodeExecutorAgent):  # type: ignore[
         親クラスはファイル名のみ追加するが、ClaudeCode 版は read_script ツールを
         持たないため、スクリプト内容そのものをプロンプトに埋め込む。
 
+        DatabaseReadError は呼び出し元に伝播する。エンリッチメントは補助的機能だが、
+        DB エラー時にエンリッチなしで続行すると暗黙のデータ欠損となるため、
+        明示的にエラーを伝播させる（フォールバック禁止ポリシー）。
+
         Args:
             task: 元のタスク文字列。
 
         Returns:
             既存スクリプト内容が追加されたタスク文字列。
+
+        Raises:
+            DatabaseReadError: list_scripts / read_script の DB 読み込み失敗時。
         """
         impl_ctx = self.executor_config.implementation_context
         if impl_ctx is None:


### PR DESCRIPTION
## Summary

_enrich_task_with_existing_scripts メソッドで、DB エラー（list_scripts / read_script の失敗）を呼び出し元に明示的に伝播させます。
エンリッチメントは補助的機能ですが、DB エラー時にエンリッチなしで続行すると暗黙のデータ欠損となるため、CLAUDE.md の「フォールバック全面禁止」ルールに従い例外を送出します。

Closes #3

## Test plan

- list_scripts の DatabaseReadError が伝播すること
- read_script の DatabaseReadError が伝播すること  
- スクリプト読み込みループの途中で エラーが発生した場合、部分結果ではなく例外が伝播すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)