### PR TITLE
refactor: テストフィクスチャを conftest.py に統合

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,19 @@ pytest_configure フックで実行。
 """
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
+from mixseek.models.member_agent import MemberAgentConfig
+from pydantic_ai.models import Model
+from quant_insight.agents.local_code_executor.models import ImplementationContext
+
+from quant_insight_plus.agents.agent import ClaudeCodeLocalCodeExecutorAgent
+
+# --- パッチ対象パス定数 ---
+INIT_STORE_PATCH = "quant_insight.agents.local_code_executor.agent.get_implementation_store"
+ENRICH_STORE_PATCH = "quant_insight_plus.agents.agent.get_implementation_store"
+MODEL_PATCH = "quant_insight_plus.agents.agent.create_authenticated_model"
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -23,3 +34,64 @@ def mock_workspace_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     workspace.mkdir()
     monkeypatch.setenv("MIXSEEK_WORKSPACE", str(workspace))
     return workspace
+
+
+@pytest.fixture
+def member_agent_config() -> MemberAgentConfig:
+    """テスト用の MemberAgentConfig を生成。"""
+    return MemberAgentConfig(
+        name="test-agent",
+        type="custom",
+        model="claudecode:claude-sonnet-4-5",
+        description="Test agent",
+        system_instruction="You are a test agent.",
+        metadata={
+            "tool_settings": {
+                "local_code_executor": {
+                    "available_data_paths": ["data/test"],
+                    "timeout_seconds": 60,
+                }
+            }
+        },
+    )
+
+
+@pytest.fixture
+def mock_store() -> MagicMock:
+    """DuckDB ストアの mock。"""
+    store = MagicMock()
+    store.table_exists.return_value = True
+    return store
+
+
+@pytest.fixture
+def mock_model() -> MagicMock:
+    """pydantic-ai Model の mock。"""
+    return MagicMock(spec=Model)
+
+
+@pytest.fixture
+@patch(INIT_STORE_PATCH)
+@patch(MODEL_PATCH)
+def agent(
+    mock_create_model: MagicMock,
+    mock_get_store: MagicMock,
+    member_agent_config: MemberAgentConfig,
+    mock_store: MagicMock,
+    mock_model: MagicMock,
+) -> ClaudeCodeLocalCodeExecutorAgent:
+    """テスト用エージェントインスタンス。"""
+    mock_create_model.return_value = mock_model
+    mock_get_store.return_value = mock_store
+    return ClaudeCodeLocalCodeExecutorAgent(member_agent_config)
+
+
+@pytest.fixture
+def implementation_context() -> ImplementationContext:
+    """テスト用の ImplementationContext。"""
+    return ImplementationContext(
+        execution_id="exec-1",
+        team_id="team-1",
+        round_number=1,
+        member_agent_name="test-agent",
+    )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,54 +2,16 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from mixseek.models.member_agent import MemberAgentConfig
-from pydantic_ai.models import Model
 
 from quant_insight_plus.agents.agent import ClaudeCodeLocalCodeExecutorAgent
-
-STORE_PATCH = "quant_insight.agents.local_code_executor.agent.get_implementation_store"
-MODEL_PATCH = "quant_insight_plus.agents.agent.create_authenticated_model"
-
-
-@pytest.fixture
-def member_agent_config() -> MemberAgentConfig:
-    """テスト用の MemberAgentConfig を生成。"""
-    return MemberAgentConfig(
-        name="test-agent",
-        type="custom",
-        model="claudecode:claude-sonnet-4-5",
-        description="Test agent",
-        system_instruction="You are a test agent.",
-        metadata={
-            "tool_settings": {
-                "local_code_executor": {
-                    "available_data_paths": ["data/test"],
-                    "timeout_seconds": 60,
-                }
-            }
-        },
-    )
-
-
-@pytest.fixture
-def mock_store() -> MagicMock:
-    """DuckDB ストアの mock。"""
-    store = MagicMock()
-    store.table_exists.return_value = True
-    return store
-
-
-@pytest.fixture
-def mock_model() -> MagicMock:
-    """pydantic-ai Model の mock。"""
-    return MagicMock(spec=Model)
+from tests.conftest import INIT_STORE_PATCH, MODEL_PATCH
 
 
 class TestClaudeCodeLocalCodeExecutorAgentInit:
     """__init__ の動作を検証するテスト。"""
 
-    @patch(STORE_PATCH)
+    @patch(INIT_STORE_PATCH)
     @patch(MODEL_PATCH)
     def test_uses_create_authenticated_model(
         self,
@@ -68,61 +30,27 @@ class TestClaudeCodeLocalCodeExecutorAgentInit:
         mock_create_model.assert_called_once_with("claudecode:claude-sonnet-4-5")
         assert agent.agent.model is mock_model
 
-    @patch(STORE_PATCH)
-    @patch(MODEL_PATCH)
     def test_no_toolsets_registered(
         self,
-        mock_create_model: MagicMock,
-        mock_get_store: MagicMock,
-        member_agent_config: MemberAgentConfig,
-        mock_store: MagicMock,
-        mock_model: MagicMock,
+        agent: ClaudeCodeLocalCodeExecutorAgent,
     ) -> None:
         """pydantic-ai ツールセットを登録しないこと（Claude Code 組み込みツールに委ねる）。"""
-        mock_create_model.return_value = mock_model
-        mock_get_store.return_value = mock_store
-
-        agent = ClaudeCodeLocalCodeExecutorAgent(member_agent_config)
-
-        # _function_toolset にツールが登録されていないことを確認
         toolset = getattr(agent.agent, "_function_toolset", None)
         assert toolset is None or len(toolset.tools) == 0
 
-    @patch(STORE_PATCH)
-    @patch(MODEL_PATCH)
     def test_inherits_executor_config(
         self,
-        mock_create_model: MagicMock,
-        mock_get_store: MagicMock,
-        member_agent_config: MemberAgentConfig,
-        mock_store: MagicMock,
-        mock_model: MagicMock,
+        agent: ClaudeCodeLocalCodeExecutorAgent,
     ) -> None:
         """親クラスの executor_config 構築ロジックを再利用すること。"""
-        mock_create_model.return_value = mock_model
-        mock_get_store.return_value = mock_store
-
-        agent = ClaudeCodeLocalCodeExecutorAgent(member_agent_config)
-
         assert agent.executor_config.available_data_paths == ["data/test"]
         assert agent.executor_config.timeout_seconds == 60
 
-    @patch(STORE_PATCH)
-    @patch(MODEL_PATCH)
     def test_output_type_default_is_str(
         self,
-        mock_create_model: MagicMock,
-        mock_get_store: MagicMock,
-        member_agent_config: MemberAgentConfig,
-        mock_store: MagicMock,
-        mock_model: MagicMock,
+        agent: ClaudeCodeLocalCodeExecutorAgent,
     ) -> None:
         """output_model 未設定時のデフォルト output_type は str であること。"""
-        mock_create_model.return_value = mock_model
-        mock_get_store.return_value = mock_store
-
-        agent = ClaudeCodeLocalCodeExecutorAgent(member_agent_config)
-
         assert agent.agent.output_type is str
 
 


### PR DESCRIPTION
## 概要

テストコード内で重複しているテストフィクスチャを conftest.py に統合し、DRY原則に従ったテスト構造にリファクタリングしました。

- **member_agent_config**, **mock_store**, **mock_model**, **agent**, **implementation_context** フィクスチャを conftest.py に移動
- パッチ対象パスの定数（INIT_STORE_PATCH, ENRICH_STORE_PATCH, MODEL_PATCH）を conftest.py で定義
- 各テストファイルから重複するフィクスチャ定義を削除し、conftest.py からインポート
- 全19テストが成功（品質チェック済み: ruff, mypy, pytest）

## テスト計画

- [x] 既存テスト19個すべてが成功することを確認
- [x] ruff によるコード品質チェック
- [x] mypy による型安全性チェック
- [x] テストフィクスチャの重複排除が成功したことを確認

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)