### PR TITLE
refactor: main() 関数から到達不能な is_patched() チェックを削除

### DIFF
--- a/src/quant_insight_plus/cli.py
+++ b/src/quant_insight_plus/cli.py
@@ -59,8 +59,4 @@ def main() -> None:
 
     quant-insight-plus コマンドで呼び出される。
     """
-    from mixseek_plus.core_patch import is_patched
-
-    if not is_patched():
-        patch_core()
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,23 @@ class TestCLIAutoRegistration:
         assert "claudecode_local_code_executor" in supported_types
 
 
+class TestMainFunction:
+    """main() 関数のデッドコード不在テスト。"""
+
+    def test_main_has_no_is_patched_check(self) -> None:
+        """main() 内に is_patched() の冗長チェックがないこと。
+
+        patch_core() はモジュールレベルで実行されるため、
+        main() 内での is_patched() チェックは到達不能コード。
+        """
+        import inspect
+
+        from quant_insight_plus.cli import main
+
+        source = inspect.getsource(main)
+        assert "is_patched" not in source
+
+
 class TestCLICommands:
     """CLI コマンド委譲テスト。"""
 


### PR DESCRIPTION
## Summary
patch_core() はモジュールレベルで実行されるため、main() 内での is_patched() チェックはデッドコード。このチェックを削除し、到達不能性を検証するテストを追加しました。

Closes #5

## Test plan
- test_main_has_no_is_patched_check(): main() 関数のソースコード内に is_patched() 文字列が含まれていないことを確認
- 既存の CLI 自動登録テスト、コマンド委譲テストが引き続き成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)