### PR TITLE
fix: Use module-level import for auth to ensure patch_core() monkey-patching is reflected

### DIFF
--- a/src/quant_insight_plus/agents/agent.py
+++ b/src/quant_insight_plus/agents/agent.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from mixseek.agents.member.base import BaseMemberAgent
 from mixseek.agents.member.factory import MemberAgentFactory
-from mixseek.core.auth import create_authenticated_model
+from mixseek.core import auth
 from mixseek.models.member_agent import MemberAgentConfig
 from pydantic_ai import Agent
 from quant_insight.agents.local_code_executor.agent import LocalCodeExecutorAgent
@@ -49,7 +49,7 @@ class ClaudeCodeLocalCodeExecutorAgent(LocalCodeExecutorAgent):  # type: ignore[
         model_settings = self._create_model_settings()
 
         # create_authenticated_model で claudecode: プレフィックスを解決
-        model = create_authenticated_model(self.config.model)
+        model = auth.create_authenticated_model(self.config.model)
 
         # ツールセットなし — Claude Code の組み込みツールを使用
         self.agent: Agent[LocalCodeExecutorConfig, Any] = Agent(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from quant_insight_plus.agents.agent import ClaudeCodeLocalCodeExecutorAgent
 # --- パッチ対象パス定数 ---
 INIT_STORE_PATCH = "quant_insight.agents.local_code_executor.agent.get_implementation_store"
 ENRICH_STORE_PATCH = "quant_insight_plus.agents.agent.get_implementation_store"
-MODEL_PATCH = "quant_insight_plus.agents.agent.create_authenticated_model"
+MODEL_PATCH = "mixseek.core.auth.create_authenticated_model"
 
 
 def pytest_configure(config: pytest.Config) -> None:


### PR DESCRIPTION
## Summary
- Changed from direct function import (`create_authenticated_model`) to module-level import (`mixseek.core.auth`)
- Ensures `patch_core()` monkey-patching is properly applied
- Updated corresponding test patch path to match the new import style

## Test plan
- Verify all quality checks pass (ruff lint/format, mypy type checking)
- Run existing test suite to confirm patch behavior works correctly
- Test agent initialization with patched auth module

🤖 Generated with [Claude Code](https://claude.com/claude-code)