### PR TITLE
refactor: Simplify MCP tool prefix

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -184,15 +184,15 @@ Leader の `system_instruction` に MCP ツールの実名が記載されてい�
 system_instruction = """
 ## メンバー
 - train-analyzer:
-    - ツール名: `mcp__pydantic_tools__delegate_to_train-analyzer`
+    - ツール名: `mcp__team__delegate_to_train-analyzer`
     - タスクの指示を `task` パラメータ（文字列）で渡す
 - submission-creator:
-    - ツール名: `mcp__pydantic_tools__delegate_to_submission-creator`
+    - ツール名: `mcp__team__delegate_to_submission-creator`
     - タスクの指示を `task` パラメータ（文字列）で渡す
 """
 ```
 
-MCP ツール名の規則: `mcp__pydantic_tools__delegate_to_{agent_name}`（`agent_name` はメンバー設定の `[agent] name`）
+MCP ツール名の規則: `mcp__team__delegate_to_{agent_name}`（`agent_name` はメンバー設定の `[agent] name`）
 
 ## 実行時エラー
 

--- a/src/quant_insight_plus/templates/agents/teams/claudecode_team.toml
+++ b/src/quant_insight_plus/templates/agents/teams/claudecode_team.toml
@@ -29,11 +29,11 @@ Submissionはアクセス不可能な未来のtestデータに対して評価さ
 
 - train-analyzer:
     - 役割: 提供されたtrainデータに対するデータ分析を行う
-    - ツール名: `mcp__pydantic_tools__delegate_to_train-analyzer`
+    - ツール名: `mcp__team__delegate_to_train-analyzer`
     - 呼び出し方: `task` パラメータに分析指示を文字列で渡す
 - submission-creator:
     - 役割: 最終Submissionスクリプトを実装し、動作確認を行った後、あなたに提供する
-    - ツール名: `mcp__pydantic_tools__delegate_to_submission-creator`
+    - ツール名: `mcp__team__delegate_to_submission-creator`
     - 呼び出し方: `task` パラメータに実装指示を文字列で渡す
 
 ## 行動規則

--- a/tests/test_leader_template.py
+++ b/tests/test_leader_template.py
@@ -10,7 +10,7 @@ import tomllib
 
 import pytest
 
-MCP_TOOL_PREFIX = "mcp__pydantic_tools__"
+MCP_TOOL_PREFIX = "mcp__team__"
 DELEGATE_TOOL_PATTERN = "delegate_to_{agent_name}"
 
 


### PR DESCRIPTION
## Summary
Simplifies the MCP tool prefix naming convention from `mcp__pydantic_tools__` to `mcp__team__` for better clarity. Updates documentation, team agent templates, and related tests to use the new simplified prefix.

Closes #28

## Test plan
- Verify team agent templates load correctly with new prefix
- Check that documentation examples match the implementation
- Confirm test_leader_template.py validates the new prefix pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)