### PR TITLE
feat(#43): Export public API for submission relay and output models

### DIFF
--- a/src/quant_insight_plus/__init__.py
+++ b/src/quant_insight_plus/__init__.py
@@ -5,9 +5,37 @@ from quant_insight_plus.agents.agent import (
     ClaudeCodeLocalCodeExecutorAgent,
     register_claudecode_quant_agents,
 )
+from quant_insight_plus.agents.output_models import (
+    FileAnalyzerOutput,
+    FileSubmitterOutput,
+)
+from quant_insight_plus.submission_relay import (
+    ANALYSIS_FILENAME,
+    SUBMISSION_FILENAME,
+    SUBMISSIONS_DIR_NAME,
+    SubmissionFileNotFoundError,
+    ensure_round_dir,
+    get_round_dir,
+    get_submission_content,
+    get_upstream_method_hash,
+    patch_submission_relay,
+    reset_submission_relay_patch,
+)
 
 __all__ = [
     "AGENT_TYPE_NAME",
+    "ANALYSIS_FILENAME",
     "ClaudeCodeLocalCodeExecutorAgent",
+    "FileAnalyzerOutput",
+    "FileSubmitterOutput",
+    "SUBMISSION_FILENAME",
+    "SUBMISSIONS_DIR_NAME",
+    "SubmissionFileNotFoundError",
+    "ensure_round_dir",
+    "get_round_dir",
+    "get_submission_content",
+    "get_upstream_method_hash",
+    "patch_submission_relay",
     "register_claudecode_quant_agents",
+    "reset_submission_relay_patch",
 ]


### PR DESCRIPTION
## Summary

Add public API exports for submission relay functions (patch_submission_relay, reset_submission_relay_patch, get_submission_content, get_round_dir, ensure_round_dir, get_upstream_method_hash) and output models (FileAnalyzerOutput, FileSubmitterOutput) to make them accessible for external consumers of the package.

Closes #43

## Test plan

- Verify that the exported symbols are accessible via `from quant_insight_plus import ...`
- Confirm that __all__ list is correctly ordered alphabetically
- Ensure no import errors occur when importing the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)